### PR TITLE
Fix small behavior issue in HSV/HSL/RGB sliders

### DIFF
--- a/src/ColorPicker/UIExtensions/HslColorSlider.cs
+++ b/src/ColorPicker/UIExtensions/HslColorSlider.cs
@@ -71,24 +71,24 @@ namespace ColorPicker.UIExtensions
             {
                 case "H":
                     {
-                        var rgbtuple = ColorSpaceHelper.HslToRgb(value, CurrentColorState.HSL_S, CurrentColorState.HSL_L);
+                        var rgbtuple = ColorSpaceHelper.HslToRgb(value, 1.0, 0.5);
                         double r = rgbtuple.Item1, g = rgbtuple.Item2, b = rgbtuple.Item3;
-                        return Color.FromArgb((byte)(CurrentColorState.A * 255), (byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
+                        return Color.FromArgb(255, (byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
                     }
                 case "S":
                     {
                         var rgbtuple = ColorSpaceHelper.HslToRgb(CurrentColorState.HSL_H, value / 255.0, CurrentColorState.HSL_L);
                         double r = rgbtuple.Item1, g = rgbtuple.Item2, b = rgbtuple.Item3;
-                        return Color.FromArgb((byte)(CurrentColorState.A * 255), (byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
+                        return Color.FromArgb(255, (byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
                     }
                 case "L":
                     {
                         var rgbtuple = ColorSpaceHelper.HslToRgb(CurrentColorState.HSL_H, CurrentColorState.HSL_S, value / 255.0);
                         double r = rgbtuple.Item1, g = rgbtuple.Item2, b = rgbtuple.Item3;
-                        return Color.FromArgb((byte)(CurrentColorState.A * 255), (byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
+                        return Color.FromArgb(255, (byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
                     }
                 default:
-                    return Color.FromArgb((byte)(CurrentColorState.A * 255), (byte)(CurrentColorState.RGB_R * 255), (byte)(CurrentColorState.RGB_G * 255), (byte)(CurrentColorState.RGB_B * 255));
+                    return Color.FromArgb(255, (byte)(CurrentColorState.RGB_R * 255), (byte)(CurrentColorState.RGB_G * 255), (byte)(CurrentColorState.RGB_B * 255));
             }
         }
     }

--- a/src/ColorPicker/UIExtensions/HsvColorSlider.cs
+++ b/src/ColorPicker/UIExtensions/HsvColorSlider.cs
@@ -57,21 +57,21 @@ namespace ColorPicker.UIExtensions
             {
                 case "H":
                     {
-                        var rgbtuple = ColorSpaceHelper.HsvToRgb(value, CurrentColorState.HSV_S, CurrentColorState.HSV_V);
+                        var rgbtuple = ColorSpaceHelper.HsvToRgb(value, 1.0, 1.0);
                         double r = rgbtuple.Item1, g = rgbtuple.Item2, b = rgbtuple.Item3;
-                        return Color.FromArgb((byte)(CurrentColorState.A * 255), (byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
+                        return Color.FromArgb(255, (byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
                     }
                 case "S":
                     {
                         var rgbtuple = ColorSpaceHelper.HsvToRgb(CurrentColorState.HSV_H, value / 255.0, CurrentColorState.HSV_V);
                         double r = rgbtuple.Item1, g = rgbtuple.Item2, b = rgbtuple.Item3;
-                        return Color.FromArgb((byte)(CurrentColorState.A * 255), (byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
+                        return Color.FromArgb(255, (byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
                     }
                 case "V":
                     {
                         var rgbtuple = ColorSpaceHelper.HsvToRgb(CurrentColorState.HSV_H, CurrentColorState.HSV_S, value / 255.0);
                         double r = rgbtuple.Item1, g = rgbtuple.Item2, b = rgbtuple.Item3;
-                        return Color.FromArgb((byte)(CurrentColorState.A * 255), (byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
+                        return Color.FromArgb(255, (byte)(r * 255), (byte)(g * 255), (byte)(b * 255));
                     }
                 default:
                     return Color.FromArgb((byte)(CurrentColorState.A * 255), (byte)(CurrentColorState.RGB_R * 255), (byte)(CurrentColorState.RGB_G * 255), (byte)(CurrentColorState.RGB_B * 255));

--- a/src/ColorPicker/UIExtensions/RgbColorSlider.cs
+++ b/src/ColorPicker/UIExtensions/RgbColorSlider.cs
@@ -38,9 +38,9 @@ namespace ColorPicker.UIExtensions
             switch (SliderArgbType)
             {
                 case "A": return Color.FromArgb((byte)value, r, g, b);
-                case "R": return Color.FromArgb(a, (byte)value, g, b);
-                case "G": return Color.FromArgb(a, r, (byte)value, b);
-                case "B": return Color.FromArgb(a, r, g, (byte)value);
+                case "R": return Color.FromArgb(255, (byte)value, g, b);
+                case "G": return Color.FromArgb(255, r, (byte)value, b);
+                case "B": return Color.FromArgb(255, r, g, (byte)value);
                 default: return Color.FromArgb(a, r, g, b);
             };
         }


### PR DESCRIPTION
-Use constant S/V and S/L values when creating hue slider colors to have same behavior as circle hue slider. 
-Also use constant alpha for all sliders (hsv, hsl, rgb) for same reason.

Original version applies the SV/SL values to the Hue slider as the user changes it. This results in a hue slider that no longer shows the colors. This should behave the same as the circular hue slider and always show all hues:
Original:
![image](https://user-images.githubusercontent.com/6061719/211212647-5bd1a33b-e935-424b-a917-920ab0cca5d7.png)

With this change:
![image](https://user-images.githubusercontent.com/6061719/211212695-aaca07b5-7998-4fc6-aaca-d4f24af77f63.png)

Additionally, when changing alpha values, all of the sliders except for the circular one were using the alpha. I think these should not be effected and let the ColorDisplay show the result:

Original:
![image](https://user-images.githubusercontent.com/6061719/211212845-4b9d5537-8230-446d-a31e-fbdcb672f2d1.png)

With this change:
![image](https://user-images.githubusercontent.com/6061719/211212884-e4ed2486-b6e8-4b19-a22d-9cb5a259bd8d.png)
