### PR TITLE
Fixed "ColorChanged" event firing multiple times per color change

### DIFF
--- a/src/ColorPicker.AvaloniaUI/PickerControlBase.cs
+++ b/src/ColorPicker.AvaloniaUI/PickerControlBase.cs
@@ -41,7 +41,7 @@ public class PickerControlBase : TemplatedControl, IColorStateStorage
     public PickerControlBase()
     {
         Color = new NotifyableColor(this);
-        Color.PropertyChanged += (sender, args) =>
+        Color.UpdateAllCompleted += (sender, args) =>
         {
             var newColor = Avalonia.Media.Color.FromArgb(
                 (byte)Math.Round(Color.A),

--- a/src/ColorPicker.Models/NotifyableColor.cs
+++ b/src/ColorPicker.Models/NotifyableColor.cs
@@ -1,9 +1,17 @@
-﻿namespace ColorPicker.Models
+﻿using System;
+
+namespace ColorPicker.Models
 {
     public class NotifyableColor : NotifyableObject
     {
         private readonly IColorStateStorage storage;
         private bool isUpdating = false;
+
+        [field: NonSerialized] public event EventHandler UpdateAllCompleted = delegate { };
+        public void RaiseUpdateAllCompleted()
+        {
+            UpdateAllCompleted?.Invoke(this, EventArgs.Empty);
+        }
 
         public NotifyableColor(IColorStateStorage colorStateStorage)
         {
@@ -157,6 +165,7 @@
             if (currentValue.HSL_H != oldValue.HSL_H) RaisePropertyChanged(nameof(HSL_H));
             if (currentValue.HSL_S != oldValue.HSL_S) RaisePropertyChanged(nameof(HSL_S));
             if (currentValue.HSL_L != oldValue.HSL_L) RaisePropertyChanged(nameof(HSL_L));
+            RaiseUpdateAllCompleted();
             isUpdating = false;
         }
     }

--- a/src/ColorPicker/PickerControlBase.cs
+++ b/src/ColorPicker/PickerControlBase.cs
@@ -28,14 +28,14 @@ namespace ColorPicker
         public PickerControlBase()
         {
             Color = new NotifyableColor(this);
-            Color.PropertyChanged += (sender, args) =>
+            Color.UpdateAllCompleted += (sender, args) =>
             {
                 var newColor = System.Windows.Media.Color.FromArgb(
                     (byte)Math.Round(Color.A),
                     (byte)Math.Round(Color.RGB_R),
                     (byte)Math.Round(Color.RGB_G),
                     (byte)Math.Round(Color.RGB_B));
-                if (newColor != previousColor)
+                if(newColor != previousColor)
                 {
                     RaiseEvent(new ColorRoutedEventArgs(ColorChangedEvent, newColor));
                     previousColor = newColor;


### PR DESCRIPTION
Summary:
Fixed the issue with `PickerControlBase.ColorChanged` event firing each time a component of the `NotifyableColor` class is changed (Up to 10 times for a single color change).

Changes:
- Added `UpdateAllCompleted` event to `NotifyableColors.cs`
- Changed event handle for `Color.PropertyChanged` to `Color.UpdateAllCompleted` in `PickerControlBase.cs` to trigger the `ColorChanged` event only once per color change.