### PR TITLE
Fix ColorChanged event firing multiple times when setting SelectedColor

### DIFF
--- a/src/ColorPicker/PickerControlBase.cs
+++ b/src/ColorPicker/PickerControlBase.cs
@@ -111,10 +111,9 @@ namespace ColorPicker
                 return;
             var newValue = (Color)args.NewValue;
             sender.ignoreColorChange = true;
-            sender.Color.A = newValue.A;
-            sender.Color.RGB_R = newValue.R;
-            sender.Color.RGB_G = newValue.G;
-            sender.Color.RGB_B = newValue.B;
+            var state = sender.ColorState;
+            state.SetARGB(newValue.A / 255.0, newValue.R / 255.0, newValue.G / 255.0, newValue.B / 255.0);
+            sender.ColorState = state;
             sender.ignoreColorChange = false;
         }
     }


### PR DESCRIPTION
## Summary
- When `SelectedColor` was set (e.g. via hex input), `OnSelectedColorPropertyChange` assigned `A`, `RGB_R`, `RGB_G`, and `RGB_B` individually, each triggering a full `ColorState` update cycle and raising `ColorChanged`
- Replaced with a single `ColorState.SetARGB` call so all components are applied in one update, firing `ColorChanged` exactly once

## Test plan
- [ ] Enter a hex value and verify `ColorChanged` fires only once
- [ ] Verify color picker visuals update correctly after hex input
- [ ] Verify programmatic `SelectedColor` changes still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)